### PR TITLE
support: add X11 support

### DIFF
--- a/wofi-emoji
+++ b/wofi-emoji
@@ -3,6 +3,7 @@ set -euo pipefail
 
 emoji="$(sed '1,/^### DATA ###$/d' $0 | wofi -p "emoji" --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n')"
 wtype "${emoji}" && wl-copy "${emoji}"
+xdotool type "${emoji}"
 exit
 ### DATA ###
 😀 grinning face face smile happy joy :D grin


### PR DESCRIPTION
* With this patch, emojis can be also placed in X11 programs using `xdotool`.
* **Note:** `wtype` won't place emojis in X11 programs, and `xdotool` won't do so in Wayland programs.