### PR TITLE
Revert automatic wl-copy.

### DIFF
--- a/wofi-emoji
+++ b/wofi-emoji
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 emoji="$(sed '1,/^### DATA ###$/d' $0 | wofi -p "emoji" --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n')"
-wtype "${emoji}" && wl-copy "${emoji}"
+wtype "${emoji}" || wl-copy "${emoji}"
 exit
 ### DATA ###
 😀 grinning face face smile happy joy :D grin


### PR DESCRIPTION
As stated in my original contribution[1], the wl-copy fallback was only there for people who can't make wtype work or have not installed it. Using `&&` here will prevent the fallback from working for them because wtype command will exit with a non-zero code. Using `;` instead of `&&` would probably have made more sense.

However, always using wl-copy has the side-effect of overwriting what's in the user's clipboard, which might not be a desirable behavior if wtype works. That's why this commit reverts back to my original contribution (with `&&` and not `;`).

Maybe we could provide the ability to copy as an option (like `--copy`), but AFAIAC, I think it would go against the absolute simplicity of this project, so I'd argue against it.

This reverts commit 2cb7c05bb04542782120b1c4991c9532eb5974d1.

[1] https://github.com/dln/wofi-emoji/pull/10#issue-1265277835