### PR TITLE
run wl-copy even if wtype is missing

### DIFF
--- a/wofi-emoji
+++ b/wofi-emoji
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 EMOJI="$(sed '1,/^### DATA ###$/d' $0 | wofi -p "emoji" --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n')"
-wtype "$EMOJI"; wl-copy "$EMOJI"
+wtype "$EMOJI" || true
+wl-copy "$EMOJI" || true
 exit
 ### DATA ###
 😀 grinning face face smile happy joy :D grin


### PR DESCRIPTION
These two commands are two different ways of getting the output and we want to always try both.