### PR TITLE
use /usr/bin/env bash shebang

### DIFF
--- a/wofi-emoji
+++ b/wofi-emoji
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 EMOJI="$(sed '1,/^### DATA ###$/d' $0 | wofi -p "emoji" --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n')"


### PR DESCRIPTION
This shebang uses bash and uses the bash that can be found via $PATH. For me it works and does not require to modify bash specific code. I have bash installed, but it's not located at /usr/bin/bash or /bin/bash.

Is this a feasible solution (to my and maybe others' issue) and mergeable in contrast to my previous suggestion?